### PR TITLE
Fix checking if an error was already added for nested validator

### DIFF
--- a/lib/active_data/model/representation.rb
+++ b/lib/active_data/model/representation.rb
@@ -81,7 +81,7 @@ module ActiveData
             errors.add(to, :'', **options)
           end
 
-          errors.delete(from) rescue nil
+          errors.delete(from)
         end
       else # up to 6.0.x
         def move_errors(from, to)

--- a/lib/active_data/model/representation.rb
+++ b/lib/active_data/model/representation.rb
@@ -77,12 +77,11 @@ module ActiveData
           errors.where(from).each do |error|
             options = error.options
             # If we generate message for built-in validation, we don't want to later escape it in our monkey-patch
-            options = options.merge(message: error.message.html_safe) unless options.key?(:message)
-
-            errors.add(to, error.type, **options)
+            options = options.merge(generated_message: error.message) unless options.key?(:message)
+            errors.add(to, :'', **options)
           end
 
-          errors.delete(from)
+          errors.delete(from) rescue nil
         end
       else # up to 6.0.x
         def move_errors(from, to)

--- a/lib/active_data/model/validations/nested.rb
+++ b/lib/active_data/model/validations/nested.rb
@@ -18,7 +18,8 @@ module ActiveData
           def self.import_errors(from, to, prefix)
             from.each do |error|
               key = "#{prefix}.#{error.attribute}"
-              to.import(error, attribute: key) unless to.added?(key, error.type, error.options)
+              ignored_options = ActiveModel::Error::CALLBACKS_OPTIONS + ActiveModel::Error::MESSAGE_OPTIONS
+              to.import(error, attribute: key) unless to.added?(key, error.type, error.options.except(*ignored_options))
             end
           end
         else # up to 6.0.x

--- a/lib/active_data/model/validations/nested.rb
+++ b/lib/active_data/model/validations/nested.rb
@@ -21,7 +21,7 @@ module ActiveData
               ignored_options = ActiveModel::Error::CALLBACKS_OPTIONS + ActiveModel::Error::MESSAGE_OPTIONS
 
               options = error.options.merge(generated_message: error.message)
-              to.add(key, :'', options) unless to.added?(key, :'', options.except(*ignored_options))
+              to.add(key, :'', **options) unless to.added?(key, :'', options.except(*ignored_options))
             end
           end
         else # up to 6.0.x

--- a/lib/active_data/model/validations/nested.rb
+++ b/lib/active_data/model/validations/nested.rb
@@ -19,7 +19,7 @@ module ActiveData
             from.each do |error|
               key = "#{prefix}.#{error.attribute}"
               ignored_options = ActiveModel::Error::CALLBACKS_OPTIONS + ActiveModel::Error::MESSAGE_OPTIONS
-              # to.import(error, attribute: key) unless to.added?(key, error.type, error.options.except(*ignored_options))
+
               options = error.options.merge(generated_message: error.message)
               to.add(key, :'', options) unless to.added?(key, :'', options.except(*ignored_options))
             end

--- a/lib/active_data/model/validations/nested.rb
+++ b/lib/active_data/model/validations/nested.rb
@@ -19,7 +19,9 @@ module ActiveData
             from.each do |error|
               key = "#{prefix}.#{error.attribute}"
               ignored_options = ActiveModel::Error::CALLBACKS_OPTIONS + ActiveModel::Error::MESSAGE_OPTIONS
-              to.import(error, attribute: key) unless to.added?(key, error.type, error.options.except(*ignored_options))
+              # to.import(error, attribute: key) unless to.added?(key, error.type, error.options.except(*ignored_options))
+              options = error.options.merge(generated_message: error.message)
+              to.add(key, :'', options) unless to.added?(key, :'', options.except(*ignored_options))
             end
           end
         else # up to 6.0.x

--- a/spec/lib/active_data/model/validations/nested_spec.rb
+++ b/spec/lib/active_data/model/validations/nested_spec.rb
@@ -10,7 +10,7 @@ describe ActiveData::Model::Validations::NestedValidator do
       primary :id, Integer
       attribute :name, String
 
-      validates_presence_of :name
+      validates_presence_of :name, message: "can't be blank"
     end
 
     stub_model(:unvalidated_assoc) do
@@ -88,6 +88,11 @@ describe ActiveData::Model::Validations::NestedValidator do
     it { is_expected.not_to be_valid }
     specify do
       expect { instance.validate }.to change { instance.errors.messages }
+        .to('validated_one.name': ["can't be blank"])
+    end
+
+    specify do
+      expect { 2.times { instance.send :run_validations! } }.to change { instance.errors.messages }
         .to('validated_one.name': ["can't be blank"])
     end
   end


### PR DESCRIPTION
[ROGUE-3287]

### Description
When 
- running validations several times (not sure why exactly, but that sometimes happens in Granite)
- having `:message` set explicitly in the options

[This](https://github.com/pyromaniac/active_data/blob/master/lib/active_data/model/validations/nested.rb#L21) check:
```ruby
to.import(error, attribute: key) unless to.added?(key, error.type, error.options)
```

Doesn't do it's job well, since it [gets](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/error.rb#L186) to the strict matching in `ActiveModel::Error`:
```ruby
options == @options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS)
```
and hence if we give `:message` in the options - it doesn't match it right.

This either seems a bug in `ActiveModel` or interface intended to be used without ever providing those keys in the options:

`ActiveModel` 6.1 and 7:
```ruby
> errors = ActiveModel::Errors.new(nil)
> errors.add(:full_name, :weired, message: 'is weired')
> errors.added?(:full_name, :weired, message: 'is weired')
=> false
> errors.added?(:full_name, :weired)
=> true

```

`ActiveModel` 6.0 however behaves as one would expect:
```ruby
> errors = ActiveModel::Errors.new(nil)
> errors.add(:full_name, :weired, message: 'is weired')
> errors.added?(:full_name, :weired, message: 'is weired')
=> true
```

### How to test
I added a spec (and also explicitly set `:message` in the tested model), that fails if we don't omit those keys
Also this fixes a spec `spec/api/lib/graphql_api/mutations/job/review_terms_spec.rb:42` in `rails-6-upgrade` branch of the platform.
### Fixing `ActiveModel`?
Maybe I'll also make a PR in rails later, to my taste seems like a bug, if they merge it, this one won't be needed

[ROGUE-3287]: https://toptal-core.atlassian.net/browse/ROGUE-3287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ