### PR TITLE
Unwrap nested errors

### DIFF
--- a/lib/active_data/model/representation.rb
+++ b/lib/active_data/model/representation.rb
@@ -71,7 +71,7 @@ module ActiveData
           source = :"#{attribute.reference}.#{attribute.column}"
 
           if ActiveModel.version >= Gem::Version.new('6.1.0')
-            nested_error = send(attribute.reference).errors.find do |error|
+            nested_error = send(attribute.reference)&.errors&.find do |error|
               error.is_a?(ActiveModel::NestedError) && error.inner_error.attribute == attribute.column.to_sym
             end
 

--- a/lib/active_data/model/validations/nested.rb
+++ b/lib/active_data/model/validations/nested.rb
@@ -15,11 +15,22 @@ module ActiveData
         end
 
         if ActiveModel.version >= Gem::Version.new('6.1.0')
-          def self.import_errors(from, to, prefix)
-            from.each do |error|
-              key = "#{prefix}.#{error.attribute}"
-              ignored_options = ActiveModel::Error::CALLBACKS_OPTIONS + ActiveModel::Error::MESSAGE_OPTIONS
-              to.import(error, attribute: key) unless to.added?(key, error.type, error.options.except(*ignored_options))
+          class << self
+            def import_errors(from, to, prefix)
+              from.each do |error|
+                error = unwrapped_error(error)
+                key = "#{prefix}.#{error.attribute}"
+                ignored_options = ActiveModel::Error::CALLBACKS_OPTIONS + ActiveModel::Error::MESSAGE_OPTIONS
+                to.import(error, attribute: key) unless to.added?(key, error.type, error.options.except(*ignored_options))
+              end
+            end
+
+            def unwrapped_error(error)
+              if error.is_a?(ActiveModel::NestedError)
+                error.inner_error
+              else
+                error
+              end
             end
           end
         else # up to 6.0.x

--- a/lib/active_data/model/validations/nested.rb
+++ b/lib/active_data/model/validations/nested.rb
@@ -18,18 +18,9 @@ module ActiveData
           class << self
             def import_errors(from, to, prefix)
               from.each do |error|
-                error = unwrapped_error(error)
                 key = "#{prefix}.#{error.attribute}"
                 ignored_options = ActiveModel::Error::CALLBACKS_OPTIONS + ActiveModel::Error::MESSAGE_OPTIONS
                 to.import(error, attribute: key) unless to.added?(key, error.type, error.options.except(*ignored_options))
-              end
-            end
-
-            def unwrapped_error(error)
-              if error.is_a?(ActiveModel::NestedError)
-                error.inner_error
-              else
-                error
               end
             end
           end


### PR DESCRIPTION
[ROGUE-3287]

### Description

This fixes spec `be rspec spec/api/lib/graphql_api/public/mutations/sign_up/create_talent_partner_applicant_mutation_spec.rb:122`

`:email` is a represented attribtute on the `role` on the corresponding BA. but `Role.belongs_to :user, autosave: true` and errors on user's email now (since 6.1) added as `ActiveModel::NestedError` instance with `attribute = :"user.email"`, whereas before it was just `:email`. And as `ActiveData::Model::Representation` expects `role.email` to be copied to `email`, it doesn't find it because `ActiveData::Model::Validations::Nested` puts it into "role.user.email" now.

I added unwrapping, that returns previous behaviour, and checked that with fix the following code in console returns the same thing in platform's master and in the upgrade branch:

```ruby
> ba_attrs = {"full_name"=>"Shawn Cartwright",
  "contact_name"=>"Noriko Koss",
  "email"=>Talent.last.email,
  "password"=>"password_secret",
  "recaptcha_response"=>"correct_token",
  "participant_uuid"=>nil,
  "appinfo_id"=>nil,
  "referrer"=>nil,
  "identifier"=>"f728d5184e4df87bf44c74efe36a180b"}

> ba = BA::SignUp::UserApplication::CreateTalentPartnerApplicant.new(ba_attrs)
> ba.tap(&:validate).errors.messages
=> {:"user.email"=>["This email has already been taken"], :email=>["This email has already been taken"]}
```

However I have some doubts:
- whether we should make patches like this to preserve the old behaviour, or rather change specs and behaviour to adjust to changed rails.
- maybe the same is somehow achievable easier, than patching like this, for example some option to not prefix nested validation attributes
- maybe something like `represents 'user.email', of: :role` would be better, not sure if AD allows something like that
- should we unwrap all the `NestedError` till the end of the chain: we'll see if some other spec fails because of that. If specs are good, then we may leave it like this, because it's only a temporary fix for upgrade, which later can be changed
- should we unwrap only if this attribute is represented

[ROGUE-3287]: https://toptal-core.atlassian.net/browse/ROGUE-3287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
